### PR TITLE
Mark widget as representing initially untitled file

### DIFF
--- a/js/src/index.js
+++ b/js/src/index.js
@@ -114,7 +114,8 @@ function activate(app, menu, browser, launcher) {
                             factory: "Notebook",
                             path: model.path,
                           })
-                          .then((widget) => {
+                          .then((widget) =>
+                            // eslint-disable-next-line no-param-reassign
                             widget.isUntitled = true;
                             widget.context.ready.then(() => {
                               widget.model.fromString(data.content);

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -115,6 +115,7 @@ function activate(app, menu, browser, launcher) {
                             path: model.path,
                           })
                           .then((widget) => {
+                            widget.isUntitled = true;
                             widget.context.ready.then(() => {
                               widget.model.fromString(data.content);
                               resolve(widget);

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -114,7 +114,7 @@ function activate(app, menu, browser, launcher) {
                             factory: "Notebook",
                             path: model.path,
                           })
-                          .then((widget) =>
+                          .then((widget) => {
                             // eslint-disable-next-line no-param-reassign
                             widget.isUntitled = true;
                             widget.context.ready.then(() => {


### PR DESCRIPTION
Fixes #173, enabling the rename-on-first-save dialog:

![demo-templates-rename-dialog](https://user-images.githubusercontent.com/5832902/202004292-83427bda-cb98-4c46-9fb5-557b3ed940b6.gif)
